### PR TITLE
Add minimal SCADA web example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# SCADA Web Application
+
+This repository contains a minimal example of a web-based SCADA application
+implemented using only the Python standard library. It simulates sensor data and
+serves a dashboard page that updates in real time using Server-Sent Events (SSE).
+
+## Running the application
+
+```
+python3 -m scada_app.server
+```
+
+Then open `http://localhost:8000` in a browser.
+
+## Testing
+
+The tests can be run with `python3 -m pytest`.

--- a/scada_app/__init__.py
+++ b/scada_app/__init__.py
@@ -1,0 +1,3 @@
+"""SCADA Web application package."""
+
+__all__ = ['server', 'sensors']

--- a/scada_app/index.html
+++ b/scada_app/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>SCADA Dashboard</title>
+    <link rel="stylesheet" href="static/styles.css">
+</head>
+<body>
+    <h1>Power Plant SCADA</h1>
+    <table id="sensor-table" border="1">
+        <thead>
+            <tr><th>Sensor</th><th>Value</th></tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <canvas id="trend" width="600" height="200"></canvas>
+    <script src="static/script.js"></script>
+</body>
+</html>

--- a/scada_app/sensors.py
+++ b/scada_app/sensors.py
@@ -1,0 +1,34 @@
+import random
+import threading
+import time
+
+class SensorData:
+    def __init__(self):
+        self.lock = threading.Lock()
+        # Example sensors
+        self.data = {
+            'temperature': 25.0,
+            'pressure': 1.0,
+            'flow': 100.0,
+        }
+        self.running = False
+
+    def start(self):
+        if not self.running:
+            self.running = True
+            threading.Thread(target=self._update_loop, daemon=True).start()
+
+    def _update_loop(self):
+        while self.running:
+            with self.lock:
+                # Randomly vary sensors
+                self.data['temperature'] += random.uniform(-0.5, 0.5)
+                self.data['pressure'] += random.uniform(-0.02, 0.02)
+                self.data['flow'] += random.uniform(-1, 1)
+            time.sleep(1)
+
+    def get_data(self):
+        with self.lock:
+            return dict(self.data)
+
+sensors = SensorData()

--- a/scada_app/server.py
+++ b/scada_app/server.py
@@ -1,0 +1,40 @@
+import json
+import os
+import time
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse
+
+from .sensors import sensors
+
+class SCADAHandler(SimpleHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == '/events':
+            self.send_response(200)
+            self.send_header('Content-type', 'text/event-stream')
+            self.send_header('Cache-Control', 'no-cache')
+            self.end_headers()
+            try:
+                while True:
+                    data = sensors.get_data()
+                    self.wfile.write(f"data: {json.dumps(data)}\n\n".encode())
+                    self.wfile.flush()
+                    time.sleep(1)
+            except BrokenPipeError:
+                pass
+        else:
+            super().do_GET()
+
+def run(host='0.0.0.0', port=8000):
+    sensors.start()
+    # Serve files from the package directory
+    os.chdir(os.path.dirname(__file__))
+    server = HTTPServer((host, port), SCADAHandler)
+    print(f"Serving on http://{host}:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+if __name__ == '__main__':
+    run()

--- a/scada_app/static/script.js
+++ b/scada_app/static/script.js
@@ -1,0 +1,43 @@
+const tableBody = document.querySelector('#sensor-table tbody');
+const trendCanvas = document.getElementById('trend');
+const ctx = trendCanvas.getContext('2d');
+const history = [];
+
+function updateTable(data) {
+    tableBody.innerHTML = '';
+    for (const [key, value] of Object.entries(data)) {
+        const row = document.createElement('tr');
+        const nameCell = document.createElement('td');
+        nameCell.textContent = key;
+        const valCell = document.createElement('td');
+        valCell.textContent = value.toFixed(2);
+        row.appendChild(nameCell);
+        row.appendChild(valCell);
+        tableBody.appendChild(row);
+    }
+}
+
+function drawTrend(value) {
+    history.push(value);
+    if (history.length > trendCanvas.width) {
+        history.shift();
+    }
+    ctx.clearRect(0, 0, trendCanvas.width, trendCanvas.height);
+    ctx.beginPath();
+    ctx.moveTo(0, trendCanvas.height - history[0]);
+    for (let i = 1; i < history.length; i++) {
+        ctx.lineTo(i, trendCanvas.height - history[i]);
+    }
+    ctx.stroke();
+}
+
+const evtSource = new EventSource('/events');
+evtsource = evtSource; // for debugging
+
+evtSource.onmessage = function(event) {
+    const data = JSON.parse(event.data);
+    updateTable(data);
+    if ('temperature' in data) {
+        drawTrend(data.temperature + 50); // scale for canvas
+    }
+};

--- a/scada_app/static/styles.css
+++ b/scada_app/static/styles.css
@@ -1,0 +1,14 @@
+body {
+    font-family: Arial, sans-serif;
+}
+#sensor-table {
+    margin-top: 1em;
+    border-collapse: collapse;
+}
+#sensor-table th, #sensor-table td {
+    padding: 0.5em 1em;
+}
+canvas {
+    margin-top: 1em;
+    border: 1px solid #ccc;
+}

--- a/scada_app/tests/test_server.py
+++ b/scada_app/tests/test_server.py
@@ -1,0 +1,35 @@
+import threading
+import time
+import urllib.request
+import unittest
+
+from scada_app.server import run
+
+HOST = '127.0.0.1'
+PORT = 8765
+
+
+def start_server():
+    threading.Thread(target=run, kwargs={'host': HOST, 'port': PORT}, daemon=True).start()
+    time.sleep(1)
+
+
+class ServerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        start_server()
+
+    def test_index_served(self):
+        with urllib.request.urlopen(f'http://{HOST}:{PORT}/') as resp:
+            self.assertEqual(resp.status, 200)
+            self.assertIn(b'SCADA', resp.read())
+
+    def test_events_stream(self):
+        req = urllib.request.Request(f'http://{HOST}:{PORT}/events')
+        with urllib.request.urlopen(req) as resp:
+            self.assertEqual(resp.status, 200)
+            self.assertEqual(resp.headers.get_content_type(), 'text/event-stream')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a small web-based SCADA example using the Python standard library
- simulate sensor data and stream updates with SSE
- provide a simple HTML/JS dashboard
- include basic tests using unittest

## Testing
- `python3 -m unittest discover -s scada_app/tests`